### PR TITLE
UXFCP-2809 (fix): Fix texts being moved above image (incorrect!)

### DIFF
--- a/includes/Transforms/MoveLeadParagraphTransform.php
+++ b/includes/Transforms/MoveLeadParagraphTransform.php
@@ -86,7 +86,6 @@ class MoveLeadParagraphTransform implements IMobileTransform {
 			'.//*[contains(concat(" ",normalize-space(@class)," ")," infobox ")]',
 			// Thumbnail images: .thumb, figure (Parsoid)
 			'.//*[contains(concat(" ",normalize-space(@class)," ")," thumb ")]',
-			'.//figure',
 		];
 		$query = '(' . implode( '|', $paths ) . ')';
 		$infobox = $xPath->query( $query, $section )->item( 0 );


### PR DESCRIPTION
Regular image should not be considered as infobox

