### PR TITLE
UGC-4299 Enable AMC by default for the users experiment

### DIFF
--- a/includes/Amc/Manager.php
+++ b/includes/Amc/Manager.php
@@ -76,9 +76,9 @@ final class Manager {
 
 	/**
 	 * Get the UGC-4299 Experiment active variant
-	 * @return string
+	 * @return string | null
 	 */
-	public function getAMCExperimentVariant(): string {
+	public function getAMCExperimentVariant(): string | null {
 		return $this->mobileContext->getRequest()->getCookie( self::EXPERIMENT_COOKIE_NAME, '' );
 	}
 

--- a/includes/Amc/Manager.php
+++ b/includes/Amc/Manager.php
@@ -11,6 +11,9 @@ use MobileContext;
  * @package MobileFrontend\Amc
  */
 final class Manager {
+	private const EXPERIMENT_COOKIE_NAME = 'experiment-enable-amc';
+	public const EXPERIMENT_ENABLE_AMC_VARIANT = 'experiment-amc-enabled-variant';
+
 	/**
 	 * A config name used to enable/disable the AMC mode
 	 */
@@ -68,4 +71,16 @@ final class Manager {
 	public function getModeIdentifier() {
 		return self::AMC_MODE_IDENTIFIER;
 	}
+
+	// START UGC-4299 Experiment enable AMC by default for users
+
+	/**
+	 * Get the UGC-4299 Experiment active variant
+	 * @return string
+	 */
+	public function getAMCExperimentVariant(): string {
+		return $this->mobileContext->getRequest()->getCookie( self::EXPERIMENT_COOKIE_NAME, '' );
+	}
+
+	// END UGC-4299 Experiment enable AMC by default for users
 }

--- a/includes/specials/SpecialMobileOptions.php
+++ b/includes/specials/SpecialMobileOptions.php
@@ -88,6 +88,13 @@ class SpecialMobileOptions extends MobileSpecialPage {
 	private function buildAMCToggle() {
 		/** @var \MobileFrontend\Amc\UserMode $userMode */
 			$userMode = $this->services->getService( 'MobileFrontend.AMC.UserMode' );
+
+			// START UGC-4299 Experiment enable AMC by default for users
+			if ( $userMode->isAMCSwitchHidden() ) {
+				return;
+			}
+			// END UGC-4299 Experiment enable AMC by default for users
+
 			$amcToggle = new OOUI\CheckboxInputWidget( [
 				'name' => 'enableAMC',
 				'infusable' => true,


### PR DESCRIPTION
https://fandom.atlassian.net/browse/UGC-4299

**Description**
- Force true/false value for AMC option for user in the experiment
- Block save AMC option value
- Hide AMC option switch in user options on mobile