### PR TITLE
Revert "UGC-4299 Enable AMC by default for the users experiment"

### DIFF
--- a/includes/Amc/Manager.php
+++ b/includes/Amc/Manager.php
@@ -11,9 +11,6 @@ use MobileContext;
  * @package MobileFrontend\Amc
  */
 final class Manager {
-	private const EXPERIMENT_COOKIE_NAME = 'experiment-enable-amc';
-	public const EXPERIMENT_ENABLE_AMC_VARIANT = 'experiment-amc-enabled-variant';
-
 	/**
 	 * A config name used to enable/disable the AMC mode
 	 */
@@ -71,16 +68,4 @@ final class Manager {
 	public function getModeIdentifier() {
 		return self::AMC_MODE_IDENTIFIER;
 	}
-
-	// START UGC-4299 Experiment enable AMC by default for users
-
-	/**
-	 * Get the UGC-4299 Experiment active variant
-	 * @return string | null
-	 */
-	public function getAMCExperimentVariant(): string | null {
-		return $this->mobileContext->getRequest()->getCookie( self::EXPERIMENT_COOKIE_NAME, '' );
-	}
-
-	// END UGC-4299 Experiment enable AMC by default for users
 }

--- a/includes/Amc/UserMode.php
+++ b/includes/Amc/UserMode.php
@@ -13,6 +13,7 @@ use RuntimeException;
 class UserMode implements IUserMode, IUserSelectableMode {
 
 	public const USER_OPTION_MODE_AMC = 'mf_amc_optin';
+
 	/**
 	 * Value in the user options when AMC is enabled
 	 */
@@ -74,14 +75,6 @@ class UserMode implements IUserMode, IUserSelectableMode {
 	 * @return bool
 	 */
 	public function isEnabled() {
-		// START UGC-4299 Experiment enable AMC by default for users
-		$experimentVariant = $this->amc->getAMCExperimentVariant();
-
-		if ( $experimentVariant ) {
-			return $experimentVariant === Manager::EXPERIMENT_ENABLE_AMC_VARIANT;
-		}
-		// END UGC-4299 Experiment enable AMC by default for users
-
 		$userOption = $this->userOptionsLookup->getOption(
 			$this->userIdentity,
 			self::USER_OPTION_MODE_AMC,
@@ -90,19 +83,6 @@ class UserMode implements IUserMode, IUserSelectableMode {
 		return $this->amc->isAvailable() &&
 			 $userOption === self::OPTION_ENABLED;
 	}
-
-	// START UGC-4299 Experiment enable AMC by default for users
-
-	/**
-	 * Get information if the AMC switch should be hidden for current user
-	 * It's require for experiment purpose UGC-4299
-	 * @return bool
-	 */
-	public function isAMCSwitchHidden(): bool {
-		return !empty( $this->amc->getAMCExperimentVariant() );
-	}
-
-	// END UGC-4299 Experiment enable AMC by default for users
 
 	/**
 	 * Set Advanced Mobile Contributions mode to enabled or disabled.
@@ -114,13 +94,6 @@ class UserMode implements IUserMode, IUserSelectableMode {
 	 * @throws RuntimeException when mode is disabled
 	 */
 	public function setEnabled( bool $isEnabled ) {
-		// START UGC-4299 Experiment enable AMC by default for users
-		$experimentVariant = $this->amc->getAMCExperimentVariant();
-		if ( $experimentVariant ) {
-			throw new RuntimeException( 'AMC Mode is not available' );
-		}
-		// END UGC-4299 Experiment enable AMC by default for users
-
 		if ( !$this->amc->isAvailable() ) {
 			throw new RuntimeException( 'AMC Mode is not available' );
 		}

--- a/includes/specials/SpecialMobileOptions.php
+++ b/includes/specials/SpecialMobileOptions.php
@@ -88,13 +88,6 @@ class SpecialMobileOptions extends MobileSpecialPage {
 	private function buildAMCToggle() {
 		/** @var \MobileFrontend\Amc\UserMode $userMode */
 			$userMode = $this->services->getService( 'MobileFrontend.AMC.UserMode' );
-
-			// START UGC-4299 Experiment enable AMC by default for users
-			if ( $userMode->isAMCSwitchHidden() ) {
-				return;
-			}
-			// END UGC-4299 Experiment enable AMC by default for users
-
 			$amcToggle = new OOUI\CheckboxInputWidget( [
 				'name' => 'enableAMC',
 				'infusable' => true,


### PR DESCRIPTION
Reverts Wikia/MobileFrontend#29

https://fandom.atlassian.net/browse/UGC-4923

We finished the experiment, so we don't need that anymore.